### PR TITLE
Nick/notebook fixes

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,1 @@
+/jupyter_execute

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
-    "nbsphinx",
+    "myst_nb",
 ]
 
 napoleon_use_param = False

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,7 +42,7 @@ Tutorials
 .. toctree::
    :maxdepth: 1
 
-   tutorials
+   tutorials.rst
 
 
 Python API

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -7,3 +7,4 @@ sphinx >= 3.5
 sphinx-argparse
 sphinx-gallery
 sphinx_rtd_theme
+myst-nb

--- a/docs/source/tutorial/CP_APR.ipynb
+++ b/docs/source/tutorial/CP_APR.ipynb
@@ -17,21 +17,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Contents"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "* [Set up a sample problem](#Set-up-a-sample-problem)\n",
-    "* [Call CP-APR](#Call-CP-APR)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Set up a sample problem"
    ]
   },
@@ -50,7 +35,6 @@
    "source": [
     "import os\n",
     "import sys\n",
-    "sys.path.insert(0, os.path.abspath('../'))\n",
     "import pyttb as ttb\n",
     "import numpy as np"
    ]
@@ -86,7 +70,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Call CP-APR"
+    "## Call CP-APR"
    ]
   },
   {
@@ -97,25 +81,6 @@
    "source": [
     "# Compute a solution\n",
     "M = ttb.cp_apr(X, R, printitn = 10);"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "M = ttb.cp_apr(X, R, 'pdnr', printitn = 10);"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Since this problem wasn't specifically crafted to be of the right structure we may fail on our first iterate here\n",
-    "M = ttb.cp_apr(X, R, 'pqnr', printitn = 10);"
    ]
   },
   {
@@ -142,7 +107,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorial/Sparse_Tensors.ipynb
+++ b/docs/source/tutorial/Sparse_Tensors.ipynb
@@ -24,38 +24,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Contents"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "* [Creating a Sptensor](#Creating-a-Sptensor)\n",
-    "* [Creating a one-dimensional Sptensor](#Creating-a-one-dimensional-Sptensor)\n",
-    "* [Creating an all-zero Sptensor](#Creating-an-all-zero-Sptensor)\n",
-    "* [Creating an empty Sptensor](#Creating-an-empty-Sptensor)\n",
-    "* [Convert a sparse tensor into a dense tensor](#Convert-a-sparse-tensor-into-a-dense-tensor)\n",
-    "* [Use ndims and size to get the size of a Sptensor](#Use-ndims-and-size-to-get-the-size-of-a-Sptensor)\n",
-    "* [Use nnz to get the number of nonzeroes of a Sptensor](#Use-nnz-to-get-the-number-of-nonzeroes-of-a-Sptensor)\n",
-    "* [Nonzero reference for a Sptensor](#Nonzero-reference-for-a-Sptensor)\n",
-    "* [Nonzero assignment for a Sptensor](#Nonzero-assignment-for-a-Sptensor)\n",
-    "* [Subscripted reference for a Sptensor](#Subscripted-reference-for-a-Sptensor)\n",
-    "* [Subscripted assignment for a Sptensor](#Subscripted-assignment-for-a-Sptensor)\n",
-    "* [Basic operations on a Sptensor](#Basic-operations-on-a-Sptensor)\n",
-    "     * [Addition](#Addition)\n",
-    "     * [Subtraction](#Subtraction)\n",
-    "     * [Multiplication](#Multiplication)\n",
-    "     * [Division](#Division)\n",
-    "     * [Power](#Power)\n",
-    "     * [Equality](#Equality)\n",
-    "* [Displaying a Sptensor](#Displaying-a-Sptensor)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Creating a Sptensor"
    ]
   },
@@ -681,7 +649,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorial/Tensors.ipynb
+++ b/docs/source/tutorial/Tensors.ipynb
@@ -24,34 +24,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Contents"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "* [Creating an empty tensor](#Creating-an-empty-tensor)\n",
-    "* [Create a tensor of all zeroes](#Create-a-tensor-of-all-zeroes)\n",
-    "* [Convert tensor to an array](#Convert-tensor-to-an-array)\n",
-    "* [Use len, ndims, and size to get the size of a tensor](#Use-len,-ndims,-and-size-to-get-the-size-of-a-tensor)\n",
-    "* [Subscripted reference of a tensor](#Subscripted-reference-of-a-tensor)\n",
-    "* [Subscripted assignment for a tensor](#Subscripted-assignment-for-a-tensor)\n",
-    "* [Basic operations on a tensor](#Basic-operations-on-a-tensor)\n",
-    "     * [Addition](#Addition)\n",
-    "     * [Subtraction](#Subtraction)\n",
-    "     * [Multiplication](#Multiplication)\n",
-    "     * [Division](#Division)\n",
-    "     * [Power](#Power)\n",
-    "     * [Equality](#Equality)\n",
-    "* [Use permute to reorder the modes of a tensor](#Use-permute-to-reorder-the-modes-of-a-tensor)\n",
-    "* [Display tensor](#Display-tensor)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Creating an empty tensor"
    ]
   },
@@ -528,7 +500,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -4,6 +4,6 @@ Tutorials
 .. toctree::
    :maxdepth: 2
 
-   ../../../tutorial/CP_APR
-   ../../../tutorial/Sparse_Tensors
-   ../../../tutorial/Tensors
+   tutorial/CP_APR
+   tutorial/Sparse_Tensors
+   tutorial/Tensors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
 ]
 doc = [
     "sphinx_rtd_theme",
+    "myst-nb",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Changes here:

1. Use myst since nbsphinx has an external `pandoc` dependency which can't just be managed by pip. Much more painful.
2. Remove notebook contents since jupyterlab auto creates a table of contents on the left AND the RTD build does the same.
3. Move notebooks to /docs/source/tutorial. We probably will want to include some details on that in our README or somewhere else for people that want to run notebooks themselves.

We don't have this automated for CI yet. So here is the rough repro (we might need to add an explicit jupyter-notebook dependency to our doc option, I assume you had to install it into your venv to run any of the notebooks good for us to clean that up too):
```bash
pip install -e ".[doc]"
sphinx-build ./docs/source ./docs/build
```

Then you should be able to open the built local read the docs to look at it.